### PR TITLE
WEP-62 move refresh logic to authStore

### DIFF
--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -23,6 +23,10 @@ describe('apiClient', () => {
       setAccessToken: vi.fn((token) => {
         authStore.accessToken = token;
       }),
+      refreshToken: vi.fn().mockImplementation(async () => {
+        authStore.accessToken = 'new-token';
+        return 'new-token';
+      }),
       logout: vi.fn().mockResolvedValue(undefined),
     };
     (useAuthStore as any).mockReturnValue(authStore);
@@ -93,12 +97,12 @@ describe('apiClient', () => {
 
     it('should refresh token on 401 and retry original request', async () => {
       mockApi.onGet('/test').replyOnce(401).onGet('/test').reply(200, { data: 'ok' });
-      mockAuth.onPost('/auth/refresh').reply(200, { accessToken: 'new-token' });
+      authStore.refreshToken.mockResolvedValue('new-token');
 
       const response = await apiClient.get('/test');
 
       expect(response.data).toEqual({ data: 'ok' });
-      expect(authStore.setAccessToken).toHaveBeenCalledWith('new-token');
+      expect(authStore.refreshToken).toHaveBeenCalled();
       expect(response.config.headers?.Authorization).toBe('Bearer new-token');
     });
 
@@ -106,43 +110,32 @@ describe('apiClient', () => {
       mockApi.onGet('/test1').replyOnce(401).onGet('/test1').reply(200, { data: 'ok1' });
       mockApi.onGet('/test2').replyOnce(401).onGet('/test2').reply(200, { data: 'ok2' });
 
-      // Delay refresh to ensure queueing
-      mockAuth.onPost('/auth/refresh').reply(async () => {
+      // Simulate first call taking time
+      authStore.refreshToken.mockImplementation(async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
-        return [200, { accessToken: 'new-token' }];
+        return 'new-token';
       });
 
       const [res1, res2] = await Promise.all([apiClient.get('/test1'), apiClient.get('/test2')]);
 
       expect(res1.data).toEqual({ data: 'ok1' });
       expect(res2.data).toEqual({ data: 'ok2' });
-      expect(mockAuth.history.post.length).toBe(1);
+      expect(authStore.refreshToken).toHaveBeenCalledTimes(2);
     });
 
-    it('should reject if newToken is null in queued request', async () => {
+    it('should reject if newToken is null from refreshToken', async () => {
       mockApi.onGet('/test1').replyOnce(401);
 
-      mockAuth.onPost('/auth/refresh').reply(200, { accessToken: null });
+      authStore.refreshToken.mockResolvedValue(null);
 
       await expect(apiClient.get('/test1')).rejects.toThrow();
     });
 
-    it('should handle refresh failure, logout and clear token', async () => {
+    it('should handle refresh failure and reject original request', async () => {
       mockApi.onGet('/test').reply(401);
-      mockAuth.onPost('/auth/refresh').reply(401, { detail: 'Refresh failed' });
-      mockAuth.onPost('/auth/logout').reply(200);
+      authStore.refreshToken.mockRejectedValue(new Error('Refresh failed'));
 
-      await expect(apiClient.get('/test')).rejects.toThrow();
-      expect(authStore.setAccessToken).toHaveBeenCalledWith(null);
-    });
-
-    it('should handle logout failure gracefully during refresh failure', async () => {
-      mockApi.onGet('/test').reply(401);
-      mockAuth.onPost('/auth/refresh').reply(401, { detail: 'Refresh failed' });
-      mockAuth.onPost('/auth/logout').reply(500);
-
-      await expect(apiClient.get('/test')).rejects.toThrow();
-      expect(authStore.setAccessToken).toHaveBeenCalledWith(null);
+      await expect(apiClient.get('/test')).rejects.toThrow('Refresh failed');
     });
 
     it('should reject non-axios errors in response interceptor with custom check', async () => {

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -95,6 +95,25 @@ describe('apiClient', () => {
       await expect(apiClient.get(path)).rejects.toThrow();
     });
 
+    it('should proceed to refresh if URL is empty', async () => {
+      mockApi.onGet('').replyOnce(401).onGet('').reply(200, { data: 'ok' });
+      authStore.refreshToken.mockResolvedValue('new-token');
+
+      const response = await apiClient.get('');
+
+      expect(response.data).toEqual({ data: 'ok' });
+      expect(authStore.refreshToken).toHaveBeenCalled();
+    });
+
+    it('should handle URL without leading slash in isAuthExcluded', async () => {
+      // auth/login (without leading slash) should be excluded after it's transformed to /auth/login
+      const path = 'auth/login';
+      mockApi.onGet('/' + path).reply(401);
+
+      await expect(apiClient.get(path)).rejects.toThrow();
+      expect(authStore.refreshToken).not.toHaveBeenCalled();
+    });
+
     it('should refresh token on 401 and retry original request', async () => {
       mockApi.onGet('/test').replyOnce(401).onGet('/test').reply(200, { data: 'ok' });
       authStore.refreshToken.mockResolvedValue('new-token');
@@ -110,17 +129,28 @@ describe('apiClient', () => {
       mockApi.onGet('/test1').replyOnce(401).onGet('/test1').reply(200, { data: 'ok1' });
       mockApi.onGet('/test2').replyOnce(401).onGet('/test2').reply(200, { data: 'ok2' });
 
-      // Simulate first call taking time
-      authStore.refreshToken.mockImplementation(async () => {
+      // Create a single shared promise to simulate the store's coalescing logic
+      let sharedPromise: Promise<string> | null = null;
+      const underlyingRefresh = vi.fn().mockImplementation(async () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
         return 'new-token';
+      });
+
+      authStore.refreshToken.mockImplementation(() => {
+        if (!sharedPromise) {
+          sharedPromise = underlyingRefresh();
+        }
+        return sharedPromise;
       });
 
       const [res1, res2] = await Promise.all([apiClient.get('/test1'), apiClient.get('/test2')]);
 
       expect(res1.data).toEqual({ data: 'ok1' });
       expect(res2.data).toEqual({ data: 'ok2' });
+      // authStore.refreshToken is called for every 401 response
       expect(authStore.refreshToken).toHaveBeenCalledTimes(2);
+      // But the underlying operation (coalesced by the store logic) is only invoked once
+      expect(underlyingRefresh).toHaveBeenCalledTimes(1);
     });
 
     it('should reject if newToken is null from refreshToken', async () => {

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -108,7 +108,7 @@ describe('apiClient', () => {
     it('should handle URL without leading slash in isAuthExcluded', async () => {
       // auth/login (without leading slash) should be excluded after it's transformed to /auth/login
       const path = 'auth/login';
-      mockApi.onGet('/' + path).reply(401);
+      mockApi.onGet('/api/' + path).reply(401);
 
       await expect(apiClient.get(path)).rejects.toThrow();
       expect(authStore.refreshToken).not.toHaveBeenCalled();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,9 +5,12 @@ import axios, {
 } from 'axios';
 import { useAuthStore } from '@/features/auth/store/auth';
 import type { LoginInfo } from '@/domain/auth/models';
-import type { ErrorResponse } from '@/api/types';
 
 const DEFAULT_TIMEOUT = 5000;
+
+interface ErrorResponse {
+  detail: string;
+}
 
 export const apiClient = axios.create({
   baseURL: '/api',
@@ -30,7 +33,7 @@ export const authClient = axios.create({
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
     const authStore = useAuthStore();
-    if (authStore.accessToken) {
+    if (authStore.accessToken && !config.headers.Authorization) {
       config.headers.Authorization = `Bearer ${authStore.accessToken}`;
     }
     return config;
@@ -45,15 +48,6 @@ export const getErrorMessage = (err: unknown): string => {
 
   const data = err.response?.data as ErrorResponse | undefined;
   return data?.detail || err.message || 'Request Failed';
-};
-
-// Refresh functionality
-let isRefreshing = false;
-let pendingRequests: ((newToken: string | null) => void)[] = [];
-
-const resolveRequests = (newToken: string | null) => {
-  pendingRequests.forEach((cb) => cb(newToken));
-  pendingRequests = [];
 };
 
 export const AUTH_EXCLUDED_PATHS = ['/auth/login', '/auth/refresh', '/auth/signup', '/auth/logout'];
@@ -77,54 +71,27 @@ apiClient.interceptors.response.use(
 
     const error = err as AxiosError;
     const originalConfig = error.config as (AxiosRequestConfig & { _retry?: boolean }) | undefined;
-    if (!originalConfig || isAuthExcluded(originalConfig.url)) {
-      return Promise.reject(error);
-    }
 
-    const status = error.response?.status;
-    if (status !== 401 || originalConfig._retry) {
+    if (
+      !originalConfig ||
+      isAuthExcluded(originalConfig.url) ||
+      error.response?.status !== 401 ||
+      originalConfig._retry
+    ) {
       return Promise.reject(error);
-    }
-
-    if (isRefreshing) {
-      // Push the request to the queue and quit.
-      return new Promise((resolve, reject) =>
-        pendingRequests.push((newToken: string | null) => {
-          if (!newToken) {
-            reject(error);
-            return;
-          }
-          originalConfig.headers = originalConfig.headers || {};
-          originalConfig.headers.Authorization = `Bearer ${newToken}`;
-          originalConfig._retry = true;
-          resolve(apiClient.request(originalConfig));
-        }),
-      );
     }
 
     originalConfig._retry = true;
-    isRefreshing = true;
+
     const authStore = useAuthStore();
-    try {
-      const { data } = await authClient.post<LoginInfo>('/auth/refresh');
-      const newToken = data.accessToken;
-      authStore.setAccessToken(newToken);
+    const newToken = await authStore.refreshToken();
+
+    if (newToken) {
       originalConfig.headers = originalConfig.headers || {};
       originalConfig.headers.Authorization = `Bearer ${newToken}`;
       return apiClient.request(originalConfig);
-    } catch (refreshError: unknown) {
-      console.log('Refresh token failed: ', getErrorMessage(refreshError));
-      try {
-        await authClient.post('/auth/logout');
-      } catch (logoutError: unknown) {
-        console.error('Logout failed: ', getErrorMessage(logoutError));
-      } finally {
-        authStore.setAccessToken(null);
-      }
-      return Promise.reject(refreshError);
-    } finally {
-      isRefreshing = false;
-      resolveRequests(authStore.accessToken);
     }
+
+    return Promise.reject(error);
   },
 );

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,7 +4,6 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 import { useAuthStore } from '@/features/auth/store/auth';
-import type { LoginInfo } from '@/domain/auth/models';
 
 const DEFAULT_TIMEOUT = 5000;
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,3 +1,0 @@
-export interface ErrorResponse {
-  detail: string;
-}

--- a/frontend/src/features/auth/store/auth.ts
+++ b/frontend/src/features/auth/store/auth.ts
@@ -4,6 +4,9 @@ import { ref, type Ref } from 'vue';
 
 import { apiClient, authClient, getErrorMessage } from '@/api/client';
 
+/** Shared promise for token refresh to prevent multiple simultaneous calls. */
+let refreshPromise: Promise<string | null> | null = null;
+
 /**
  * Store for managing authentication and user session.
  */
@@ -73,6 +76,35 @@ export const useAuthStore = defineStore('auth-store', () => {
   };
 
   /**
+   * Refreshes the access token using the refresh token.
+   * Deduplicates multiple calls into a single promise.
+   * @returns A promise that resolves to the new access token or null on failure.
+   */
+  const refreshToken = async (): Promise<string | null> => {
+    if (refreshPromise) {
+      return refreshPromise;
+    }
+
+    refreshPromise = (async () => {
+      try {
+        const { data } = await authClient.post<LoginInfo>('/auth/refresh');
+        setAccessToken(data.access_token);
+        console.log('Token refreshed successfully');
+        return data.access_token;
+      } catch (err: unknown) {
+        console.error('Token refresh failed:', getErrorMessage(err));
+        setAccessToken(null);
+        user.value = null;
+        return null;
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+
+    return refreshPromise;
+  };
+
+  /**
    * Initializes the authentication state from refresh token.
    * @returns A promise that resolves when initialization is complete.
    */
@@ -80,12 +112,12 @@ export const useAuthStore = defineStore('auth-store', () => {
     if (isInitialized.value) return;
 
     try {
-      const { data } = await authClient.post<LoginInfo>('/auth/refresh');
-      setAccessToken(data.access_token);
-      console.log('Initialized access_token from refresh');
-      await _setUser();
+      const token = await refreshToken();
+      if (token) {
+        await _setUser();
+      }
     } catch (err: unknown) {
-      console.log('No valid refresh token found: ', getErrorMessage(err));
+      console.log('Initialization failed: ', getErrorMessage(err));
     } finally {
       isInitialized.value = true;
     }
@@ -108,5 +140,6 @@ export const useAuthStore = defineStore('auth-store', () => {
     login,
     signup,
     logout,
+    refreshToken,
   };
 });

--- a/frontend/src/features/auth/store/auth.ts
+++ b/frontend/src/features/auth/store/auth.ts
@@ -17,6 +17,8 @@ export const useAuthStore = defineStore('auth-store', () => {
   const user: Ref<UserInfo | null> = ref(null);
   /** Whether the authentication state has been initialized. */
   const isInitialized = ref(false);
+  /** Version of the current session to track changes. */
+  const sessionVersion = ref(0);
 
   /**
    * Sets the access token.
@@ -43,6 +45,7 @@ export const useAuthStore = defineStore('auth-store', () => {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
     });
+    sessionVersion.value++;
     accessToken.value = data.access_token;
     await _setUser();
   };
@@ -65,43 +68,54 @@ export const useAuthStore = defineStore('auth-store', () => {
    * @returns A promise that resolves when the logout is complete.
    */
   const logout = async () => {
+    sessionVersion.value++;
+    const currentToken = accessToken.value;
+    setAccessToken(null);
+    user.value = null;
     try {
-      await apiClient.post('/auth/logout');
+      // Include token manually if available to avoid apiClient's refresh recursion
+      const headers = currentToken ? { Authorization: `Bearer ${currentToken}` } : {};
+      await authClient.post('/auth/logout', null, { headers });
     } catch (err: unknown) {
       console.error(`An error during logout: ${err}`);
     }
-    setAccessToken(null);
-    user.value = null;
-    console.log('Cleared access_token');
+    console.log('Cleared access_token and session');
   };
 
   /**
    * Refreshes the access token using the refresh token.
    * Deduplicates multiple calls into a single promise.
-   * @returns A promise that resolves to the new access token or null on failure.
+   * @returns A promise that resolves to the new access token.
+   * @throws Error on refresh failure.
    */
-  const refreshToken = async (): Promise<string | null> => {
+  const refreshToken = async (): Promise<string> => {
+    const currentVersion = sessionVersion.value;
     if (refreshPromise) {
-      return refreshPromise;
+      return refreshPromise as Promise<string>;
     }
 
     refreshPromise = (async () => {
       try {
         const { data } = await authClient.post<LoginInfo>('/auth/refresh');
+
+        if (sessionVersion.value !== currentVersion) {
+          console.warn('Session changed during refresh, ignoring result');
+          throw new Error('Session changed during refresh');
+        }
+
         setAccessToken(data.access_token);
         console.log('Token refreshed successfully');
         return data.access_token;
       } catch (err: unknown) {
         console.error('Token refresh failed:', getErrorMessage(err));
-        setAccessToken(null);
-        user.value = null;
-        return null;
+        await logout();
+        throw err;
       } finally {
         refreshPromise = null;
       }
     })();
 
-    return refreshPromise;
+    return refreshPromise as Promise<string>;
   };
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Overhauled token refresh handling: refresh logic deduplicates concurrent attempts and simplified retry behavior.

* **Bug Fixes**
  * Preserves Authorization header when present; fixes auth-excluded path matching.
  * Improved session/version handling during refresh, and clearer behavior when refresh yields no token or fails.

* **Tests**
  * Updated and added tests for refresh, retry/coalescing, empty-request URLs, and excluded-path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->