### PR TITLE
WEP-71 email login form

### DIFF
--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -55,8 +55,8 @@ async def test_create_user__valid_data__user_created_and_logged_in(client, usern
 
     assert response.status_code == status.HTTP_201_CREATED
     body = response.json()
-    assert body.pop('id')
-    assert body == {'email': EMAIL, 'is_active': True, 'username': username, 'avatar_url': None}
+    assert 'access_token' in body and body['access_token']
+    assert body['token_type'] == TokenType.BEARER
 
 
 async def test_create_user__duplicate_email__conflict_error(client, created_user):
@@ -93,7 +93,7 @@ async def test_login__valid_credentials__token_returned(client, created_user):
 
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
-    assert 'access_token' in body
+    assert 'access_token' in body and body['access_token']
     assert body['token_type'] == TokenType.BEARER
 
 

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -55,7 +55,8 @@ async def test_create_user__valid_data__user_created_and_logged_in(client, usern
 
     assert response.status_code == status.HTTP_201_CREATED
     body = response.json()
-    assert 'access_token' in body and body['access_token']
+    assert 'access_token' in body
+    assert body['access_token']
     assert body['token_type'] == TokenType.BEARER
 
 
@@ -93,7 +94,8 @@ async def test_login__valid_credentials__token_returned(client, created_user):
 
     assert response.status_code == status.HTTP_200_OK
     body = response.json()
-    assert 'access_token' in body and body['access_token']
+    assert 'access_token' in body
+    assert body['access_token']
     assert body['token_type'] == TokenType.BEARER
 
 
@@ -157,11 +159,12 @@ async def test_refresh_token__no_cookies_in_request__error_raised(auth_client_fo
     assert response.json() == {'detail': error.detail}
 
 
-async def test_refresh_token__refresh_token_far_from_expire__no_cookies_in_response(auth_client_for_created_user):
+async def test_refresh_token__refresh_token_far_from_expire__same_token_in_cookies(auth_client_for_created_user):
+    old_token = auth_client_for_created_user.cookies.get(REFRESH_TOKEN_COOKIE_NAME)
     response = await auth_client_for_created_user.post(AppUrl.AUTH_REFRESH)
 
     assert response.status_code == status.HTTP_200_OK
-    assert not response.cookies.get(REFRESH_TOKEN_COOKIE_NAME)
+    assert old_token == response.cookies.get(REFRESH_TOKEN_COOKIE_NAME)
 
 
 async def test_refresh_token__refresh_token_about_to_expire__new_token_in_cookies(auth_client_for_created_user):

--- a/backend/week_eat_planner/api/auth.py
+++ b/backend/week_eat_planner/api/auth.py
@@ -9,7 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from week_eat_planner.api.dependencies.auth_deps import get_current_active_user
 from week_eat_planner.api.schemas import Token, UserCreate, UserRead
-from week_eat_planner.config import settings
 from week_eat_planner.constants import AppUrl, REFRESH_TOKEN_COOKIE_NAME, TokenType
 from week_eat_planner.db.session_maker import db
 from week_eat_planner.exceptions import (
@@ -21,17 +20,19 @@ from week_eat_planner.exceptions import (
     TokenForbidden,
     TokenRevokedException,
 )
+from week_eat_planner.helpers import set_refresh_cookie
 from week_eat_planner.services.auth_service import AuthService
 
 router = APIRouter(tags=['Auth'])
 
 
-@router.post(AppUrl.AUTH_SIGNUP, response_model=UserRead, status_code=status.HTTP_201_CREATED)
+@router.post(AppUrl.AUTH_SIGNUP, response_model=Token, status_code=status.HTTP_201_CREATED)
 async def create_user(
     user_data: UserCreate,
     session: Annotated[AsyncSession, Depends(db.get_db_commit)],
     request: Request,
-) -> UserRead:
+    response: Response,
+) -> Token:
     """Registers a new user.
 
     Args:
@@ -49,9 +50,12 @@ async def create_user(
         logger.warning('Authorization header should not be set for sign up requests.')
         raise SignUpWithAuthException()
 
-    created_user = await AuthService(session).register_user(user_data)
+    auth_service = AuthService(session)
+    created_user = await auth_service.register_user(user_data)
+    access_token, refresh_token = await auth_service.login(created_user.email, user_data.password)
+    set_refresh_cookie(response, refresh_token)
 
-    return UserRead.model_validate(created_user)
+    return Token(access_token=access_token, token_type=TokenType.BEARER)
 
 
 @router.post(AppUrl.AUTH_LOGIN, response_model=Token)
@@ -82,15 +86,7 @@ async def login(
         raise LoginWithAuthException()
 
     access_token, refresh_token = await AuthService(session).login(user_data.username, user_data.password)
-    response.set_cookie(
-        key=REFRESH_TOKEN_COOKIE_NAME,
-        value=refresh_token,
-        httponly=True,
-        secure=not settings.IS_DEBUG,
-        samesite='lax' if settings.IS_DEBUG else 'strict',
-        max_age=settings.REFRESH_TOKEN_TTL * 24 * 60 * 60,
-        path='/',
-    )
+    set_refresh_cookie(response, refresh_token)
 
     return Token(access_token=access_token, token_type=TokenType.BEARER)
 
@@ -121,15 +117,7 @@ async def refresh_tokens(
 
     access_token, refresh_token = await AuthService(session).refresh_tokens(cookie_token)
     if cookie_token != refresh_token:
-        response.set_cookie(
-            key=REFRESH_TOKEN_COOKIE_NAME,
-            value=refresh_token,
-            httponly=True,
-            secure=not settings.IS_DEBUG,
-            samesite='lax' if settings.IS_DEBUG else 'strict',
-            max_age=settings.REFRESH_TOKEN_TTL * 24 * 60 * 60,
-            path='/',
-        )
+        set_refresh_cookie(response, refresh_token)
 
     return Token(access_token=access_token, token_type=TokenType.BEARER)
 

--- a/backend/week_eat_planner/api/auth.py
+++ b/backend/week_eat_planner/api/auth.py
@@ -33,13 +33,13 @@ async def create_user(
     request: Request,
     response: Response,
 ) -> Token:
-    """Registers a new user.
+    """Registers a new user and authenticates them.
 
     Args:
         user_data: The user's email and password.
 
     Returns:
-        The public information for the newly created user.
+        A Token object containing the access token and token type.
 
     Raises:
         SignUpWithAuthException: If the request contains an Authorization header.
@@ -116,8 +116,7 @@ async def refresh_tokens(
         raise RefreshTokenMissingException()
 
     access_token, refresh_token = await AuthService(session).refresh_tokens(cookie_token)
-    if cookie_token != refresh_token:
-        set_refresh_cookie(response, refresh_token)
+    set_refresh_cookie(response, refresh_token)
 
     return Token(access_token=access_token, token_type=TokenType.BEARER)
 

--- a/backend/week_eat_planner/helpers.py
+++ b/backend/week_eat_planner/helpers.py
@@ -2,10 +2,11 @@
 
 from uuid import UUID
 
-from fastapi import UploadFile
+from fastapi import Response, UploadFile
 from uuid_utils import uuid7
 
-from week_eat_planner.constants import ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE_BYTES
+from week_eat_planner.config import settings
+from week_eat_planner.constants import ALLOWED_IMAGE_TYPES, MAX_IMAGE_SIZE_BYTES, REFRESH_TOKEN_COOKIE_NAME
 from week_eat_planner.exceptions import (
     ImageContentTypeMissingException,
     ImageTooLargeException,
@@ -14,17 +15,28 @@ from week_eat_planner.exceptions import (
 
 
 def generate_uuid7() -> UUID:
-    """uuid7() returns uuid_utils.UUID but the DB doesn't recognise that.
+    """Generate a UUID v7 (time-ordered UUID).
 
+    uuid7() returns uuid_utils.UUID but the DB doesn't recognise that.
     Instead, convert the new value to uuid.UUID type.
 
     Returns:
-        uuid.UUID uuid7() representation.
+        A UUID v7 instance.
     """
     return UUID(str(uuid7()))
 
 
 async def check_image_suitable(image: UploadFile) -> None:
+    """Validate an uploaded image for type and size.
+
+    Args:
+        image: The uploaded file to validate.
+
+    Raises:
+        ImageContentTypeMissingException: If the image has no content type.
+        UnsupportedImageTypeException: If the image type is not allowed.
+        ImageTooLargeException: If the image exceeds the size limit.
+    """
     if not image.content_type:
         raise ImageContentTypeMissingException
 
@@ -38,3 +50,21 @@ async def check_image_suitable(image: UploadFile) -> None:
 
     # Reset file pointer for storage client
     await image.seek(0)
+
+
+def set_refresh_cookie(response: Response, refresh_token: str) -> None:
+    """Set the refresh token as an HTTP-only cookie.
+
+    Args:
+        response: The FastAPI response object to set the cookie on.
+        refresh_token: The refresh token value to store in the cookie.
+    """
+    response.set_cookie(
+        key=REFRESH_TOKEN_COOKIE_NAME,
+        value=refresh_token,
+        httponly=True,
+        secure=not settings.IS_DEBUG,
+        samesite='lax' if settings.IS_DEBUG else 'strict',
+        max_age=settings.REFRESH_TOKEN_TTL * 24 * 60 * 60,
+        path='/',
+    )

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -18,7 +18,7 @@ import { toast } from 'vue-sonner';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
 
 vi.mock('vue-router', () => ({
-  useRouter: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
 }));
 
 vi.mock('vue-sonner', () => ({
@@ -88,6 +88,20 @@ describe('auth api', () => {
 
       expect(accessToken.value).toBe('new-token');
       expect(cache.invalidateQueries).toHaveBeenCalled();
+    });
+
+    it('shows toast and redirects to weeks on success', async () => {
+      const pushMock = vi.fn();
+      vi.mocked(useRouter).mockReturnValue({ push: pushMock } as any);
+
+      const mutationConfig = loginMutation();
+      const loginInfo = { access_token: 'new-token', token_type: 'bearer' };
+
+      // @ts-ignore
+      await mutationConfig.onSuccess(loginInfo);
+
+      expect(toast.success).toHaveBeenCalledWith('Logged in successfully!');
+      expect(pushMock).toHaveBeenCalledWith({ name: ROUTE_NAMES.WEEK });
     });
   });
 

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -108,13 +108,13 @@ describe('auth api', () => {
   describe('signupMutation', () => {
     it('returns user data on success', async () => {
       const payload = { email: 'test@example.com', username: 'test', password: 'password' };
-      const user = { user_id: '1', email: 'test@example.com', is_active: true };
-      mockApi.onPost('/auth/signup').reply(200, user);
+      const loginInfo = { access_token: 'new-token', token_type: 'bearer' };
+      mockApi.onPost('/auth/signup').reply(201, loginInfo);
 
       const mutationConfig = signupMutation();
       // @ts-ignore
       const result = await mutationConfig.mutation(payload);
-      expect(result).toEqual(user);
+      expect(result).toEqual(loginInfo);
     });
 
     it('shows toast and redirects to login on success', async () => {

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -51,7 +51,7 @@ describe('auth api', () => {
   afterEach(() => {
     mockApi.restore();
     mockAuth.restore();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('isAuthenticated is true when accessToken has a value', () => {

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -101,7 +101,7 @@ describe('auth api', () => {
       await mutationConfig.onSuccess(loginInfo);
 
       expect(toast.success).toHaveBeenCalledWith('Logged in successfully!');
-      expect(pushMock).toHaveBeenCalledWith({ name: ROUTE_NAMES.WEEK });
+      expect(pushMock).toHaveBeenCalledWith({ name: ROUTE_NAMES.WEEKS });
     });
   });
 
@@ -122,12 +122,13 @@ describe('auth api', () => {
       vi.mocked(useRouter).mockReturnValue({ push: pushMock } as any);
 
       const mutationConfig = signupMutation();
+      const loginInfo = { access_token: 'new-token', token_type: 'bearer' };
 
       // @ts-ignore
-      await mutationConfig.onSuccess();
+      await mutationConfig.onSuccess(loginInfo);
 
       expect(toast.success).toHaveBeenCalledWith('Registration complete!');
-      expect(pushMock).toHaveBeenCalledWith({ name: ROUTE_NAMES.LOGIN });
+      expect(pushMock).toHaveBeenCalledWith({ name: ROUTE_NAMES.WEEKS });
     });
   });
 

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -106,7 +106,7 @@ describe('auth api', () => {
   });
 
   describe('signupMutation', () => {
-    it('returns user data on success', async () => {
+    it('returns token data on success', async () => {
       const payload = { email: 'test@example.com', username: 'test', password: 'password' };
       const loginInfo = { access_token: 'new-token', token_type: 'bearer' };
       mockApi.onPost('/auth/signup').reply(201, loginInfo);
@@ -117,7 +117,7 @@ describe('auth api', () => {
       expect(result).toEqual(loginInfo);
     });
 
-    it('shows toast and redirects to login on success', async () => {
+    it('shows toast and redirects to weeks on success', async () => {
       const pushMock = vi.fn();
       vi.mocked(useRouter).mockReturnValue({ push: pushMock } as any);
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -83,7 +83,7 @@ export const loginMutation = defineMutation(() => {
       toast.success('Logged in successfully!');
       accessToken.value = data.access_token;
       queryCache.invalidateQueries({ key: AUTH_KEYS.user() });
-      await router.push({ name: ROUTE_NAMES.WEEK });
+      await router.push({ name: ROUTE_NAMES.WEEKS });
     },
   };
 });
@@ -93,12 +93,16 @@ export const loginMutation = defineMutation(() => {
  */
 export const signupMutation = defineMutation(() => {
   const router = useRouter();
+  const queryCache = useQueryCache();
+
   return {
     mutation: (payload: SignUpPayload) =>
-      apiClient.post<UserData>('/auth/signup', payload).then((res) => res.data),
-    onSuccess: async () => {
+      apiClient.post<LoginInfo>('/auth/signup', payload).then((res) => res.data),
+    onSuccess: async (data: LoginInfo) => {
       toast.success('Registration complete!');
-      await router.push({ name: ROUTE_NAMES.LOGIN });
+      accessToken.value = data.access_token;
+      queryCache.invalidateQueries({ key: AUTH_KEYS.user() });
+      await router.push({ name: ROUTE_NAMES.WEEKS });
     },
   };
 });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -25,12 +25,18 @@ export interface LoginInfo {
 }
 
 /**
+ * Payload to loign a user.
+ */
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+/**
  * Payload for registering a new user.
  */
-export interface SignUpPayload {
-  email: string;
+export interface SignUpPayload extends LoginPayload {
   username: string;
-  password: string;
 }
 
 /**
@@ -65,14 +71,19 @@ export const getUserQuery = defineQueryOptions(() => ({
  * Stores the received access token and invalidates user data cache.
  */
 export const loginMutation = defineMutation(() => {
+  const router = useRouter();
   const queryCache = useQueryCache();
 
   return {
-    mutation: (params: URLSearchParams) =>
-      apiClient.post<LoginInfo>('/auth/login', params).then((res) => res.data),
-    onSuccess: (data: LoginInfo) => {
+    mutation: (payload: LoginPayload) => {
+      const params = new URLSearchParams({ username: payload.email, password: payload.password });
+      return apiClient.post<LoginInfo>('/auth/login', params).then((res) => res.data);
+    },
+    onSuccess: async (data: LoginInfo) => {
+      toast.success('Logged in successfully!');
       accessToken.value = data.access_token;
       queryCache.invalidateQueries({ key: AUTH_KEYS.user() });
+      await router.push({ name: ROUTE_NAMES.WEEK });
     },
   };
 });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -25,7 +25,7 @@ export interface LoginInfo {
 }
 
 /**
- * Payload to loign a user.
+ * Payload to login a user.
  */
 export interface LoginPayload {
   email: string;

--- a/frontend/src/components/ui/field/FieldLabel.vue
+++ b/frontend/src/components/ui/field/FieldLabel.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
     :class="
       cn(
         'group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50',
-        'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>[data-slot=field]]:p-4',
+        'has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-4',
         'has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10',
         props.class,
       )

--- a/frontend/src/features/auth/components/AuthLoginForm.vue
+++ b/frontend/src/features/auth/components/AuthLoginForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <form id="signup-form" novalidate @submit.prevent="onSubmit">
+  <form id="login-form" novalidate @submit.prevent="onSubmit">
     <FieldSet>
       <FieldGroup>
         <Field>
@@ -7,41 +7,30 @@
           <Input
             id="email"
             v-model="email"
+            :class="{ 'border-destructive': errors.email || error }"
             type="email"
-            :class="{ 'border-destructive': errors.email }"
             placeholder="your@email.com"
           />
-          <FieldError>{{ errors.email }}</FieldError>
-        </Field>
-        <Field>
-          <FieldLabel for="username"> Username </FieldLabel>
-          <Input
-            id="username"
-            v-model="username"
-            type="text"
-            :class="{ 'border-destructive': errors.username }"
-            placeholder="Your username"
-          />
-          <FieldError>{{ errors.username }}</FieldError>
+          <FieldError> {{ errors.email }}</FieldError>
         </Field>
         <Field>
           <FieldLabel for="password"> Password </FieldLabel>
           <Input
             id="password"
             v-model="password"
+            :class="{ 'border-destructive': errors.password || error }"
             type="password"
-            :class="{ 'border-destructive': errors.password }"
             placeholder="Your password"
           />
-          <FieldError>{{ errors.password }}</FieldError>
+          <FieldError> {{ errors.password }}</FieldError>
         </Field>
       </FieldGroup>
 
       <FieldError v-if="error">{{ error.message }}</FieldError>
 
-      <Button type="submit" :disabled="!meta.valid || isLoading">
+      <Button type="submit" class="w-full cursor-pointer" :disabled="!meta.valid || isLoading">
         <Spinner v-if="isLoading" />
-        {{ isLoading ? 'Signing up...' : 'Sign up' }}
+        {{ isLoading ? 'Logging in...' : 'Login' }}
       </Button>
     </FieldSet>
   </form>
@@ -53,7 +42,7 @@ import { toTypedSchema } from '@vee-validate/zod';
 import * as zod from 'zod';
 
 import { useMutation } from '@pinia/colada';
-import { signupMutation } from '@/api/auth';
+import { loginMutation } from '@/api/auth';
 
 import { Button } from '@/components/ui/button';
 import { Field, FieldError, FieldGroup, FieldLabel, FieldSet } from '@/components/ui/field';
@@ -65,7 +54,6 @@ const schema = zod.object({
     .string()
     .min(1, { error: 'This is required' })
     .pipe(zod.email({ error: 'Invalid email' })),
-  username: zod.string().min(1, { error: 'This is required' }),
   password: zod
     .string()
     .min(1, { error: 'This is required' })
@@ -77,16 +65,14 @@ const { handleSubmit, errors, meta } = useForm({
   validationSchema: toTypedSchema(schema),
   initialValues: {
     email: '',
-    username: '',
     password: '',
   },
 });
 
 const { value: email } = useField<FormValues['email']>('email');
-const { value: username } = useField<FormValues['username']>('username');
 const { value: password } = useField<FormValues['password']>('password');
 
-const { mutateAsync: signup, isLoading, error } = useMutation(signupMutation());
+const { mutate: login, isLoading, error } = useMutation(loginMutation());
 
-const onSubmit = handleSubmit((values: FormValues) => signup(values));
+const onSubmit = handleSubmit((values: FormValues) => login(values));
 </script>

--- a/frontend/src/features/auth/components/__tests__/AuthLoginForm.spec.ts
+++ b/frontend/src/features/auth/components/__tests__/AuthLoginForm.spec.ts
@@ -124,7 +124,7 @@ describe('AuthLoginForm', () => {
     expect(wrapper.find('form').text()).toContain('Invalid credentials');
   });
 
-  it('disables submit button when form is invalid or loading', () => {
+  it('disables submit button when form is invalid or loading', async () => {
     (useMutation as any).mockReturnValue({
       mutate: vi.fn(),
       isLoading: ref(false),
@@ -134,10 +134,13 @@ describe('AuthLoginForm', () => {
     const wrapper = mountComponent();
     const button = wrapper.find('button[type="submit"]');
 
-    // Button should be disabled when form is invalid or loading
-    // The exact behavior depends on vee-validate's meta.valid state
-    const buttonText = button.text();
-    // Either button shows "Logging in..." (when loading) or "Login" (when not)
-    expect(buttonText === 'Login' || buttonText === 'Logging in...').toBe(true);
+    // Form starts invalid (empty fields), so button should be disabled
+    // Need to trigger validation to update meta.valid
+    await wrapper.find('input#email').setValue('test@example.com');
+    await wrapper.find('input#password').setValue('password123');
+    await flushPromises();
+
+    // Now form should be valid and button should NOT be disabled
+    expect(button.attributes('disabled')).toBeUndefined();
   });
 });

--- a/frontend/src/features/auth/components/__tests__/AuthLoginForm.spec.ts
+++ b/frontend/src/features/auth/components/__tests__/AuthLoginForm.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AuthLoginForm from '../AuthLoginForm.vue';
+import { createRouter, createWebHistory } from 'vue-router';
+import { ROUTE_NAMES } from '@/domain/router/routeNames';
+import { useMutation } from '@pinia/colada';
+import { ref } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+
+// Mock auth API
+vi.mock('@/api/auth', () => ({
+  loginMutation: vi.fn(),
+}));
+
+// Mock Pinia Colada
+vi.mock('@pinia/colada', () => ({
+  useMutation: vi.fn(),
+}));
+
+describe('AuthLoginForm', () => {
+  let router: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    router = createRouter({
+      history: createWebHistory(),
+      routes: [
+        { path: '/', name: ROUTE_NAMES.HOME, component: { template: '<div>Home</div>' } },
+        {
+          path: '/login',
+          name: ROUTE_NAMES.LOGIN,
+          component: { template: '<div>Login</div>' },
+        },
+      ],
+    });
+  });
+
+  const mountComponent = (props = {}) => {
+    return mount(AuthLoginForm, {
+      props,
+      global: {
+        plugins: [router],
+        stubs: {
+          Button: {
+            template: '<button :disabled="disabled" type="submit"><slot /></button>',
+            props: ['disabled'],
+          },
+          Spinner: { template: '<div class="spinner" />' },
+          Input: {
+            template:
+              '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+            props: ['modelValue'],
+            emits: ['update:modelValue'],
+          },
+          Field: { template: '<div><slot /></div>' },
+          FieldGroup: { template: '<div><slot /></div>' },
+          FieldLabel: { template: '<label><slot /></label>' },
+          FieldSet: { template: '<fieldset><slot /></fieldset>' },
+          FieldError: { template: '<div class="field-error"><slot /></div>' },
+        },
+      },
+    });
+  };
+
+  it('renders login form fields', () => {
+    (useMutation as any).mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: ref(false),
+      error: ref(null),
+    });
+
+    const wrapper = mountComponent();
+    expect(wrapper.find('input[type="email"]').exists()).toBe(true);
+    expect(wrapper.find('input#email').exists()).toBe(true);
+    expect(wrapper.find('input[type="password"]').exists()).toBe(true);
+    expect(wrapper.find('input#password').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').text()).toBe('Login');
+  });
+
+  it('submits the form with correct values', async () => {
+    const loginMutate = vi.fn().mockResolvedValue({ email: 'user@example.com' });
+
+    (useMutation as any).mockImplementation(() => {
+      return { mutate: loginMutate, isLoading: ref(false), error: ref(null) };
+    });
+
+    const wrapper = mountComponent();
+
+    await wrapper.find('input#email').setValue('user@example.com');
+    await wrapper.find('input#password').setValue('password123');
+
+    // @ts-ignore
+    await wrapper.vm.onSubmit();
+    await flushPromises();
+
+    expect(loginMutate).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      password: 'password123',
+    });
+  });
+
+  it('shows loading state during submission', () => {
+    (useMutation as any).mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: ref(true),
+      error: ref(null),
+    });
+
+    const wrapper = mountComponent();
+    expect(wrapper.find('.spinner').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').text()).toBe('Logging in...');
+  });
+
+  it('shows error message when login fails', () => {
+    (useMutation as any).mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: ref(false),
+      error: ref({ message: 'Invalid credentials' }),
+    });
+
+    const wrapper = mountComponent();
+    // Error is rendered at FieldSet level in a FieldError component
+    expect(wrapper.find('form').text()).toContain('Invalid credentials');
+  });
+
+  it('disables submit button when form is invalid or loading', () => {
+    (useMutation as any).mockReturnValue({
+      mutate: vi.fn(),
+      isLoading: ref(false),
+      error: ref(null),
+    });
+
+    const wrapper = mountComponent();
+    const button = wrapper.find('button[type="submit"]');
+
+    // Button should be disabled when form is invalid or loading
+    // The exact behavior depends on vee-validate's meta.valid state
+    const buttonText = button.text();
+    // Either button shows "Logging in..." (when loading) or "Login" (when not)
+    expect(buttonText === 'Login' || buttonText === 'Logging in...').toBe(true);
+  });
+});

--- a/frontend/src/features/auth/components/__tests__/AuthLoginForm.spec.ts
+++ b/frontend/src/features/auth/components/__tests__/AuthLoginForm.spec.ts
@@ -4,6 +4,7 @@ import AuthLoginForm from '../AuthLoginForm.vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
 import { useMutation } from '@pinia/colada';
+import { useForm } from 'vee-validate';
 import { ref } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 
@@ -16,6 +17,52 @@ vi.mock('@/api/auth', () => ({
 vi.mock('@pinia/colada', () => ({
   useMutation: vi.fn(),
 }));
+
+// Mock vee-validate
+vi.mock('vee-validate', () => ({
+  useField: vi.fn(() => ({ value: ref('') })),
+  useForm: vi.fn(() => ({
+    handleSubmit: (cb: any) => (event: Event) => {
+      // Prevent default to stop native form submission
+      event?.preventDefault?.();
+      // Extract values from the form's native inputs if available
+      const form = event?.target as HTMLFormElement;
+      let values: Record<string, string> = {};
+
+      if (form) {
+        const formData = new FormData(form);
+        for (const [key, value] of formData.entries()) {
+          values[key] = value as string;
+        }
+      }
+
+      // If no form values, try to get from component state via the event
+      // This is a fallback for when using custom inputs (like Input component)
+      if (!values.email && !values.password) {
+        const submitter = (event as any)?.submitter;
+        // Try to get values from the wrapper's vm if available
+      }
+
+      return cb(values);
+    },
+    errors: ref({}),
+    meta: ref({ valid: true }),
+  })),
+  toTypedSchema: vi.fn((schema) => schema),
+}));
+
+// Mock @vee-validate/zod
+vi.mock('@vee-validate/zod', () => ({
+  toTypedSchema: vi.fn((schema) => schema),
+}));
+
+// Mock zod
+vi.mock('zod', async () => {
+  const actual = await vi.importActual('zod');
+  return {
+    ...actual,
+  };
+});
 
 describe('AuthLoginForm', () => {
   let router: any;
@@ -43,15 +90,14 @@ describe('AuthLoginForm', () => {
         plugins: [router],
         stubs: {
           Button: {
-            template: '<button :disabled="disabled" type="submit"><slot /></button>',
-            props: ['disabled'],
+            template: '<button type="submit"><slot /></button>',
           },
           Spinner: { template: '<div class="spinner" />' },
           Input: {
             template:
-              '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
-            props: ['modelValue'],
-            emits: ['update:modelValue'],
+              '<input :id="id" :name="id" :value="modelValue" :type="type" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\', $event)" />',
+            props: ['modelValue', 'id', 'type', 'placeholder'],
+            emits: ['update:modelValue', 'blur'],
           },
           Field: { template: '<div><slot /></div>' },
           FieldGroup: { template: '<div><slot /></div>' },
@@ -86,12 +132,23 @@ describe('AuthLoginForm', () => {
     });
 
     const wrapper = mountComponent();
+    const emailInput = wrapper.find('input#email');
+    const passwordInput = wrapper.find('input#password');
+    await emailInput.setValue('user@example.com');
+    await passwordInput.setValue('password123');
 
-    await wrapper.find('input#email').setValue('user@example.com');
-    await wrapper.find('input#password').setValue('password123');
+    // Trigger input events to update v-model
+    await emailInput.trigger('input');
+    await passwordInput.trigger('input');
 
-    // @ts-ignore
-    await wrapper.vm.onSubmit();
+    // Force vee-validate to validate
+    await wrapper.vm.$nextTick();
+
+    // Submit the form via the DOM
+    const form = wrapper.find('form');
+    await form.trigger('submit.prevent', {
+      submitter: wrapper.find('button[type="submit"]').element,
+    });
     await flushPromises();
 
     expect(loginMutate).toHaveBeenCalledWith({
@@ -125,22 +182,35 @@ describe('AuthLoginForm', () => {
   });
 
   it('disables submit button when form is invalid or loading', async () => {
+    const isLoading = ref(false);
+    const meta = ref({ valid: false });
+
     (useMutation as any).mockReturnValue({
       mutate: vi.fn(),
-      isLoading: ref(false),
+      isLoading,
       error: ref(null),
+    });
+
+    (useForm as any).mockReturnValue({
+      handleSubmit: vi.fn(),
+      errors: ref({}),
+      meta,
     });
 
     const wrapper = mountComponent();
     const button = wrapper.find('button[type="submit"]');
 
-    // Form starts invalid (empty fields), so button should be disabled
-    // Need to trigger validation to update meta.valid
-    await wrapper.find('input#email').setValue('test@example.com');
-    await wrapper.find('input#password').setValue('password123');
-    await flushPromises();
+    // 1. Assert disabled when form is invalid
+    expect(button.attributes('disabled')).toBeDefined();
 
-    // Now form should be valid and button should NOT be disabled
+    // 2. Assert enabled when form is valid
+    meta.value.valid = true;
+    await wrapper.vm.$nextTick();
     expect(button.attributes('disabled')).toBeUndefined();
+
+    // 3. Assert disabled when loading
+    isLoading.value = true;
+    await wrapper.vm.$nextTick();
+    expect(button.attributes('disabled')).toBeDefined();
   });
 });

--- a/frontend/src/features/auth/components/__tests__/AuthSocialButtons.spec.ts
+++ b/frontend/src/features/auth/components/__tests__/AuthSocialButtons.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AuthSocialButtons from '../AuthSocialButtons.vue';
+
+describe('AuthSocialButtons', () => {
+  const mountComponent = () => {
+    return mount(AuthSocialButtons, {
+      global: {
+        stubs: {
+          Button: {
+            template:
+              '<button :disabled="disabled" variant="outline" class="w-full"><slot /></button>',
+            props: ['disabled', 'variant'],
+          },
+        },
+      },
+    });
+  };
+
+  it('renders the OAuth container', () => {
+    const wrapper = mountComponent();
+    expect(wrapper.find('#oauth-container').exists()).toBe(true);
+  });
+
+  it('renders Google and Facebook buttons', () => {
+    const wrapper = mountComponent();
+    const buttons = wrapper.findAll('button');
+
+    expect(buttons.length).toBe(2);
+    expect(buttons[0].text()).toContain('Google');
+    expect(buttons[1].text()).toContain('Facebook');
+  });
+
+  it('disables both OAuth buttons', () => {
+    const wrapper = mountComponent();
+    const buttons = wrapper.findAll('button');
+
+    expect(buttons[0].attributes('disabled')).toBeDefined();
+    expect(buttons[1].attributes('disabled')).toBeDefined();
+  });
+
+  it('applies correct styling classes', () => {
+    const wrapper = mountComponent();
+    const container = wrapper.find('#oauth-container');
+
+    expect(container.classes()).toContain('flex');
+    expect(container.classes()).toContain('flex-col');
+    expect(container.classes()).toContain('gap-3');
+  });
+});

--- a/frontend/src/pages/Auth/LoginPage.vue
+++ b/frontend/src/pages/Auth/LoginPage.vue
@@ -1,43 +1,20 @@
 <template>
-  <div class="login-page-container">
-    <AuthCard v-if="!isAuthenticated" title="Welcome back" description="Login to your account">
+  <div id="login-form-container">
+    <AuthCard title="Welcome back" description="Login with your account">
       <template #default>
-        <form @submit.prevent="handleLogin">
-          <FieldSet>
-            <FieldGroup>
-              <Field>
-                <FieldLabel for="email"> Email </FieldLabel>
-                <Input id="email" v-model="email" type="email" placeholder="your@email.com" />
-              </Field>
-              <Field>
-                <FieldLabel for="password"> Password </FieldLabel>
-                <Input
-                  id="password"
-                  v-model="password"
-                  type="password"
-                  placeholder="Your password"
-                />
-              </Field>
-            </FieldGroup>
-
-            <Button type="submit" class="w-full cursor-pointer" :disabled="btnDisabled">
-              <Spinner v-if="isLoading" />
-              {{ isLoading ? 'Logging in...' : 'Login' }}
-            </Button>
-          </FieldSet>
-        </form>
+        <AuthLoginForm />
         <FieldSeparator class="my-3"> Or </FieldSeparator>
         <AuthSocialButtons />
       </template>
 
       <template #footer>
-        <CardDescription>
+        <CardDescription class="text-sm">
           Forgot your password?
           <router-link
             :to="{ name: ROUTE_NAMES.FORGOT_PASSWORD }"
             class="font-semibold text-brand-primary hover:underline"
           >
-            Reset it
+            Reset it!
           </router-link>
         </CardDescription>
         <CardDescription>
@@ -51,60 +28,15 @@
         </CardDescription>
       </template>
     </AuthCard>
-
-    <template v-else>
-      <div class="space-y-6 mt-6 text-center text-base text-base-color">
-        <p>You are already logged in.</p>
-        <p class="text-sm text-muted-foreground">You can continue planning your meals!</p>
-        <Button as-child>
-          <router-link :to="{ name: ROUTE_NAMES.WEEKS }">Go to planning</router-link>
-        </Button>
-      </div>
-    </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { ROUTE_NAMES } from '@/domain/router/routeNames';
 
 import AuthCard from '@/features/auth/components/AuthCard.vue';
+import AuthLoginForm from '@/features/auth/components/AuthLoginForm.vue';
 import AuthSocialButtons from '@/features/auth/components/AuthSocialButtons.vue';
-import { Button } from '@/components/ui/button';
 import { CardDescription } from '@/components/ui/card';
-import { Field, FieldGroup, FieldLabel, FieldSeparator, FieldSet } from '@/components/ui/field';
-import { Spinner } from '@/components/ui/spinner';
-import { Input } from '@/components/ui/input';
-
-import { ROUTE_NAMES } from '@/domain/router/routeNames';
-import { useMutation } from '@pinia/colada';
-import { toast } from '@/components/ui/sonner';
-import { isAuthenticated, loginMutation } from '@/api/auth';
-
-const router = useRouter();
-const route = useRoute();
-
-const email = ref('');
-const password = ref('');
-const btnDisabled = computed(
-  () => isLoading.value || !email.value.length || password.value.length < 6,
-);
-
-const { mutateAsync: login, isLoading, error } = useMutation(loginMutation());
-
-const handleLogin = async () => {
-  const params = new URLSearchParams({ username: email.value, password: password.value });
-  await login(params);
-  if (!error.value) {
-    toast.success('Logged in successfully');
-    const redirect = Array.isArray(route.query.redirect)
-      ? route.query.redirect[0]
-      : route.query.redirect;
-    await router.push(
-      typeof redirect === 'string' && redirect.startsWith('/app')
-        ? redirect
-        : { name: ROUTE_NAMES.WEEKS },
-    );
-  }
-};
+import { FieldSeparator } from '@/components/ui/field';
 </script>

--- a/frontend/src/pages/Auth/__tests__/LoginPage.spec.ts
+++ b/frontend/src/pages/Auth/__tests__/LoginPage.spec.ts
@@ -44,22 +44,17 @@ describe('LoginPage', () => {
 
   it('contains a link to the signup page', () => {
     const wrapper = mountComponent();
-    const links = wrapper.findAll('a');
 
-    // First link is forgot password, second is signup
-    const signupLink = links[1];
+    const signupLink = wrapper.find('a[href="/signup"]');
 
     expect(signupLink.exists()).toBe(true);
-    expect(signupLink.attributes('href')).toBe('/signup');
     expect(signupLink.text()).toContain('Register!');
   });
 
   it('contains a link to the forgot password page', () => {
     const wrapper = mountComponent();
-    const links = wrapper.findAll('a');
 
-    // First link is forgot password
-    const forgotPasswordLink = links[0];
+    const forgotPasswordLink = wrapper.find('a[href="/forgot-password"]');
 
     expect(forgotPasswordLink.exists()).toBe(true);
     expect(forgotPasswordLink.text()).toContain('Reset it!');

--- a/frontend/src/pages/Auth/__tests__/LoginPage.spec.ts
+++ b/frontend/src/pages/Auth/__tests__/LoginPage.spec.ts
@@ -1,53 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import LoginPage from '../LoginPage.vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
-import { accessToken, isAuthenticated, loginMutation } from '@/api/auth';
-import { useMutation } from '@pinia/colada';
-import { ref, computed } from 'vue';
-
-// Mock auth API
-vi.mock('@/api/auth', async () => {
-  const { ref, computed } = await import('vue');
-  const accessToken = ref(null);
-  return {
-    accessToken,
-    isAuthenticated: computed(() => !!accessToken.value),
-    loginMutation: vi.fn(),
-  };
-});
-
-// Mock Pinia Colada
-vi.mock('@pinia/colada', () => ({
-  useMutation: vi.fn(),
-}));
 
 describe('LoginPage', () => {
-  let router: any;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    (accessToken as any).value = null;
-
-    router = createRouter({
-      history: createWebHistory(),
-      routes: [
-        { path: '/', name: ROUTE_NAMES.HOME, component: { template: '<div>Home</div>' } },
-        { path: '/login', name: ROUTE_NAMES.LOGIN, component: { template: '<div>Login</div>' } },
-        {
-          path: '/app/weeks',
-          name: ROUTE_NAMES.WEEKS,
-          component: { template: '<div>Weeks</div>' },
-        },
-        { path: '/signup', name: ROUTE_NAMES.SIGNUP, component: { template: '<div>Signup</div>' } },
-        {
-          path: '/forgot-password',
-          name: ROUTE_NAMES.FORGOT_PASSWORD,
-          component: { template: '<div>Forgot Password</div>' },
-        },
-      ],
-    });
+  const router = createRouter({
+    history: createWebHistory(),
+    routes: [
+      { path: '/login', name: ROUTE_NAMES.LOGIN, component: { template: '<div>Login</div>' } },
+      { path: '/signup', name: ROUTE_NAMES.SIGNUP, component: { template: '<div>Signup</div>' } },
+      {
+        path: '/forgot-password',
+        name: ROUTE_NAMES.FORGOT_PASSWORD,
+        component: { template: '<div>Forgot Password</div>' },
+      },
+    ],
   });
 
   const mountComponent = () => {
@@ -55,120 +23,45 @@ describe('LoginPage', () => {
       global: {
         plugins: [router],
         stubs: {
-          AuthCard: { template: '<div><slot name="header" /><slot /><slot name="footer" /></div>' },
-          AuthFooter: { template: '<div><slot /></div>' },
-          Button: { template: '<button><slot /></button>' },
-          Spinner: { template: '<div class="spinner" />' },
-          Input: {
-            template:
-              '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
-            props: ['modelValue'],
-          },
-          Field: { template: '<div><slot /></div>' },
-          FieldGroup: { template: '<div><slot /></div>' },
-          FieldLabel: { template: '<label><slot /></label>' },
-          FieldSeparator: { template: '<div><slot /></div>' },
-          FieldSet: { template: '<fieldset><slot /></fieldset>' },
-          'router-link': true,
+          AuthCard: { template: '<div class="auth-card"><slot /><slot name="footer" /></div>' },
+          AuthLoginForm: { template: '<div class="login-form" />' },
+          AuthSocialButtons: { template: '<div class="social-buttons" />' },
+          FieldSeparator: { template: '<div class="separator"><slot /></div>' },
+          CardDescription: { template: '<p><slot /></p>' },
         },
       },
     });
   };
 
-  it('renders login form when not authenticated', () => {
-    (useMutation as any).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isLoading: ref(false),
-      error: ref(null),
-    });
-
+  it('renders the login page with all components', () => {
     const wrapper = mountComponent();
-    expect(wrapper.find('form').exists()).toBe(true);
-    expect(wrapper.find('input[type="email"]').exists()).toBe(true);
-    expect(wrapper.find('input[type="password"]').exists()).toBe(true);
+
+    expect(wrapper.find('.auth-card').exists()).toBe(true);
+    expect(wrapper.find('.login-form').exists()).toBe(true);
+    expect(wrapper.find('.social-buttons').exists()).toBe(true);
+    expect(wrapper.find('.separator').text()).toBe('Or');
   });
 
-  it('shows already logged in message when authenticated', async () => {
-    (accessToken as any).value = 'token';
-    (useMutation as any).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isLoading: ref(false),
-      error: ref(null),
-    });
-
+  it('contains a link to the signup page', () => {
     const wrapper = mountComponent();
-    expect(wrapper.text()).toContain('You are already logged in');
-    expect(wrapper.find('form').exists()).toBe(false);
+    const links = wrapper.findAll('a');
+
+    // First link is forgot password, second is signup
+    const signupLink = links[1];
+
+    expect(signupLink.exists()).toBe(true);
+    expect(signupLink.attributes('href')).toBe('/signup');
+    expect(signupLink.text()).toContain('Register!');
   });
 
-  it('disables login button when inputs are invalid', async () => {
-    (useMutation as any).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isLoading: ref(false),
-      error: ref(null),
-    });
-
+  it('contains a link to the forgot password page', () => {
     const wrapper = mountComponent();
-    const submitBtn = wrapper.find('button[type="submit"]');
+    const links = wrapper.findAll('a');
 
-    expect(submitBtn.attributes('disabled')).toBeDefined();
+    // First link is forgot password
+    const forgotPasswordLink = links[0];
 
-    await wrapper.find('input[type="email"]').setValue('test@example.com');
-    expect(submitBtn.attributes('disabled')).toBeDefined(); // password still empty
-
-    await wrapper.find('input[type="password"]').setValue('short');
-    expect(submitBtn.attributes('disabled')).toBeDefined(); // password < 6 chars
-
-    await wrapper.find('input[type="password"]').setValue('password123');
-    expect(submitBtn.attributes('disabled')).toBeUndefined();
-  });
-
-  it('calls login mutation on form submit', async () => {
-    const mutateAsync = vi.fn().mockResolvedValue({});
-    (useMutation as any).mockReturnValue({
-      mutateAsync,
-      isLoading: ref(false),
-      error: ref(null),
-    });
-
-    const wrapper = mountComponent();
-    await wrapper.find('input[type="email"]').setValue('test@example.com');
-    await wrapper.find('input[type="password"]').setValue('password123');
-
-    await wrapper.find('form').trigger('submit.prevent');
-
-    expect(mutateAsync).toHaveBeenCalled();
-    const callArgs = mutateAsync.mock.calls[0][0];
-    expect(callArgs.get('username')).toBe('test@example.com');
-    expect(callArgs.get('password')).toBe('password123');
-  });
-
-  it('redirects to weeks page on successful login', async () => {
-    const pushSpy = vi.spyOn(router, 'push');
-    (useMutation as any).mockReturnValue({
-      mutateAsync: vi.fn().mockResolvedValue({}),
-      isLoading: ref(false),
-      error: ref(null),
-    });
-
-    const wrapper = mountComponent();
-    await wrapper.find('input[type="email"]').setValue('test@example.com');
-    await wrapper.find('input[type="password"]').setValue('password123');
-
-    await wrapper.find('form').trigger('submit.prevent');
-
-    expect(pushSpy).toHaveBeenCalledWith({ name: ROUTE_NAMES.WEEKS });
-  });
-
-  it('shows loading state during login', () => {
-    (useMutation as any).mockReturnValue({
-      mutateAsync: vi.fn(),
-      isLoading: ref(true),
-      error: ref(null),
-    });
-
-    const wrapper = mountComponent();
-    expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined();
-    expect(wrapper.text()).toContain('Logging in...');
+    expect(forgotPasswordLink.exists()).toBe(true);
+    expect(forgotPasswordLink.text()).toContain('Reset it!');
   });
 });


### PR DESCRIPTION
- Moved auth forms from page-level to component-level:
  - LoginPage.vue is now a thin wrapper
  - Added AuthLoginForm.vue (login form with vee-validate + zod)
  - Added AuthSignUpForm.vue (signup form)
  - Added AuthSocialButtons.vue (social login buttons)

- Backend changes:
  - auth.py: streamlined endpoint handlers
  - helpers.py: added set_refresh_cookie helper
  - test_auth.py: updated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signup now returns tokens and automatically logs users in, redirecting to the weeks dashboard
  * New standalone login form component with validation, loading states, error display, and social buttons

* **Refactor**
  * Centralized refresh-token cookie handling across auth flows
  * Login page simplified by delegating UI/submit logic to the new form component
  * Signup form input styling and password validation message refined

* **Style**
  * Adjusted label padding selector affecting field spacing

* **Tests**
  * Updated and added auth tests to cover token-based responses, form behavior, toasts, and redirects
<!-- end of auto-generated comment: release notes by coderabbit.ai -->