### PR TITLE
WEP-85 fix init

### DIFF
--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -15,6 +15,7 @@ import { useQuery, useQueryCache } from '@pinia/colada';
 import { useRouter } from 'vue-router';
 import { toast } from 'vue-sonner';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
+import { USER_KEYS } from '../user';
 
 vi.mock('vue-router', () => ({
   useRouter: vi.fn(() => ({ push: vi.fn() })),
@@ -153,22 +154,19 @@ describe('auth api', () => {
   describe('initAuth', () => {
     it('sets isAuthenticated and seeds cache when profile fetch succeeds', async () => {
       const mockData = { id: '1' };
+      mockApi.onGet('/user').reply(200, mockData);
       localStorage.setItem('isLogged', 'true');
-      vi.mocked(useQuery).mockReturnValue({
-        refresh: vi.fn().mockResolvedValue({ status: 'success', data: mockData }),
-      } as any);
+      const queryCache = useQueryCache();
 
       await initAuth();
       expect(isAuthenticated.value).toBe(true);
       expect(localStorage.getItem('isLogged')).toBe('true');
-      expect(useQuery).toHaveBeenCalled();
+      expect(queryCache.setQueryData).toHaveBeenCalledWith(USER_KEYS.profile(), mockData);
     });
 
     it('sets isAuthenticated to false when profile fetch fails', async () => {
       isAuthenticated.value = true;
-      vi.mocked(useQuery).mockReturnValue({
-        refresh: vi.fn().mockResolvedValue({ status: 'error', error: new Error('401') }),
-      } as any);
+      mockApi.onGet('/user').reply(401);
 
       await initAuth();
       expect(isAuthenticated.value).toBe(false);

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -167,10 +167,12 @@ describe('auth api', () => {
     it('sets isAuthenticated to false when profile fetch fails', async () => {
       isAuthenticated.value = true;
       mockApi.onGet('/user').reply(401);
+      const queryCache = useQueryCache();
 
       await initAuth();
       expect(isAuthenticated.value).toBe(false);
       expect(localStorage.getItem('isLogged')).toBeNull();
+      expect(queryCache.invalidateQueries).toHaveBeenCalledWith({ key: USER_KEYS.profile() });
     });
   });
 

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -56,6 +56,7 @@ describe('auth api', () => {
 
   it('isAuthenticated is false initially', () => {
     expect(isAuthenticated.value).toBe(false);
+    expect(localStorage.getItem('isLogged')).toBeNull();
   });
 
   describe('loginMutation', () => {
@@ -152,12 +153,14 @@ describe('auth api', () => {
   describe('initAuth', () => {
     it('sets isAuthenticated and seeds cache when profile fetch succeeds', async () => {
       const mockData = { id: '1' };
+      localStorage.setItem('isLogged', 'true');
       vi.mocked(useQuery).mockReturnValue({
         refresh: vi.fn().mockResolvedValue({ status: 'success', data: mockData }),
       } as any);
 
       await initAuth();
       expect(isAuthenticated.value).toBe(true);
+      expect(localStorage.getItem('isLogged')).toBe('true');
       expect(useQuery).toHaveBeenCalled();
     });
 
@@ -169,6 +172,7 @@ describe('auth api', () => {
 
       await initAuth();
       expect(isAuthenticated.value).toBe(false);
+      expect(localStorage.getItem('isLogged')).toBeNull();
     });
   });
 

--- a/frontend/src/api/__tests__/auth.spec.ts
+++ b/frontend/src/api/__tests__/auth.spec.ts
@@ -11,7 +11,7 @@ import {
 import { apiClient, authClient } from '../client';
 import MockAdapter from 'axios-mock-adapter';
 import { createPinia, setActivePinia } from 'pinia';
-import { useQueryCache } from '@pinia/colada';
+import { useQuery, useQueryCache } from '@pinia/colada';
 import { useRouter } from 'vue-router';
 import { toast } from 'vue-sonner';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
@@ -28,6 +28,7 @@ vi.mock('@pinia/colada', () => ({
   defineQueryOptions: (fn: any) => fn,
   defineMutation: (fn: any) => fn,
   useQueryCache: vi.fn(),
+  useQuery: vi.fn(),
 }));
 
 describe('auth api', () => {
@@ -149,18 +150,24 @@ describe('auth api', () => {
   });
 
   describe('initAuth', () => {
-    it('sets isAuthenticated when refresh succeeds', async () => {
-      mockAuth.onPost('/auth/refresh').reply(200);
+    it('sets isAuthenticated and seeds cache when profile fetch succeeds', async () => {
+      const mockData = { id: '1' };
+      vi.mocked(useQuery).mockReturnValue({
+        refresh: vi.fn().mockResolvedValue({ status: 'success', data: mockData }),
+      } as any);
 
       await initAuth();
       expect(isAuthenticated.value).toBe(true);
+      expect(useQuery).toHaveBeenCalled();
     });
 
-    it('sets isAuthenticated to false when refresh fails', async () => {
+    it('sets isAuthenticated to false when profile fetch fails', async () => {
       isAuthenticated.value = true;
-      mockAuth.onPost('/auth/refresh').reply(401);
+      vi.mocked(useQuery).mockReturnValue({
+        refresh: vi.fn().mockResolvedValue({ status: 'error', error: new Error('401') }),
+      } as any);
 
-      await expect(initAuth()).rejects.toThrow();
+      await initAuth();
       expect(isAuthenticated.value).toBe(false);
     });
   });

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,10 +1,10 @@
 import { ref } from 'vue';
-import { defineMutation, useQueryCache } from '@pinia/colada';
+import { defineMutation, useQuery, useQueryCache } from '@pinia/colada';
 import { apiClient, authClient } from './client';
 import { useRouter } from 'vue-router';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
 import { toast } from 'vue-sonner';
-import { USER_KEYS } from './user';
+import { USER_KEYS, getUserQuery } from './user';
 
 /**
  * Payload to login a user.
@@ -125,12 +125,24 @@ export const refreshToken = async () => {
 };
 
 /**
- * Initializes the authentication state by attempting to refresh the token.
+ * Initializes the authentication state by attempting to fetch the user profile.
  * This should be called once when the application starts to restore the session.
  *
  * @returns A promise that resolves when initialization is complete.
  */
-export const initAuth = async () => await refreshToken();
+export const initAuth = async () => {
+  const { refresh } = useQuery(getUserQuery());
+
+  const state = await refresh();
+
+  if (state.status === 'success') {
+    isAuthenticated.value = true;
+    localStorage.setItem('isLogged', 'true');
+  } else {
+    isAuthenticated.value = false;
+    localStorage.removeItem('isLogged');
+  }
+};
 
 /**
  * Mutation for authenticating a user via Google OAuth.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -141,6 +141,7 @@ export const initAuth = async () => {
   } catch (err) {
     isAuthenticated.value = false;
     localStorage.removeItem('isLogged');
+    queryCache.invalidateQueries({ key: USER_KEYS.profile() });
   }
 };
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -4,7 +4,7 @@ import { apiClient, authClient } from './client';
 import { useRouter } from 'vue-router';
 import { ROUTE_NAMES } from '@/domain/router/routeNames';
 import { toast } from 'vue-sonner';
-import { USER_KEYS, getUserQuery } from './user';
+import { USER_KEYS, getUserQuery, getUserProfile } from './user';
 
 /**
  * Payload to login a user.
@@ -131,14 +131,14 @@ export const refreshToken = async () => {
  * @returns A promise that resolves when initialization is complete.
  */
 export const initAuth = async () => {
-  const { refresh } = useQuery(getUserQuery());
+  const queryCache = useQueryCache();
 
-  const state = await refresh();
-
-  if (state.status === 'success') {
+  try {
+    const profile = await getUserProfile();
     isAuthenticated.value = true;
     localStorage.setItem('isLogged', 'true');
-  } else {
+    queryCache.setQueryData(USER_KEYS.profile(), profile);
+  } catch (err) {
     isAuthenticated.value = false;
     localStorage.removeItem('isLogged');
   }

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -47,11 +47,17 @@ export interface UserPassPayload {
 }
 
 /**
+ * Fetches the current authenticated user's profile.
+ * @returns A promise that resolves with the user data.
+ */
+export const getUserProfile = () => apiClient.get<UserData>('/user').then((res) => res.data);
+
+/**
  * Query options for fetching the current authenticated user's profile.
  */
 export const getUserQuery = defineQueryOptions(() => ({
   key: USER_KEYS.profile(),
-  query: () => apiClient.get<UserData>('/user').then((res) => res.data),
+  query: getUserProfile,
   staleTime: 60_000,
 }));
 

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -13,7 +13,7 @@ export const USER_KEYS = {
    * Key for the current user's profile.
    * @returns Hierarchical cache key.
    */
-  profile: () => [USER_KEYS.root, 'profile'],
+  profile: () => [...USER_KEYS.root, 'profile'],
 };
 
 /**

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -8,7 +8,7 @@ import { isAuthenticated } from './auth';
  */
 export const USER_KEYS = {
   /** Base key for all user-related data. */
-  root: 'user' as const,
+  root: ['user'] as const,
   /**
    * Key for the current user's profile.
    * @returns Hierarchical cache key.


### PR DESCRIPTION
Try /api/users instead of refreshing tokens right away

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session startup now restores authentication by fetching and caching the current user profile; it sets or clears the persistent "logged" flag accordingly.
  * User profile cache key structure adjusted for more consistent caching and predictable cache seeding/invalidation.

* **Tests**
  * Authentication tests updated to assert initial state, transitions of authentication state, persistent flag behavior, and that the profile cache is seeded on success or cleared on failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/s1r3m/week-eat-planner/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->